### PR TITLE
Add basic MimePost PHP SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+composer.lock

--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
-dev3
+# MimePost PHP SDK
+
+A simple and beginner‑friendly PHP client for the [MimePost](https://mimepost.com/) API.  
+It wraps a subset of the endpoints defined in the provided Postman collection and can be easily extended.
+
+## Installation
+
+Use [Composer](https://getcomposer.org/):
+
+```bash
+composer require mimepost/mimepost-php
+```
+
+If you are not using Composer, include the `src/Client.php` file manually.
+
+## Usage
+
+```php
+require 'vendor/autoload.php';
+
+$client = new MimePost\Client('YOUR_API_TOKEN');
+
+// Send an email using a template
+$response = $client->sendEmail([
+    'template_uid' => 'welcome_template',
+    'subject'      => 'Hello from MimePost',
+    'from_email'   => 'sender@example.com',
+    'to'           => [ ['email' => 'user@example.com'] ],
+]);
+
+print_r($response);
+```
+
+Additional helpers:
+
+```php
+$templates = $client->listTemplates();
+$domainList = $client->listDomains();
+$stats      = $client->getStats(['start_date' => '20250101', 'end_date' => '20250131']);
+```
+
+## Extending
+
+The `Client::request()` method is public. You can call any MimePost endpoint:
+
+```php
+$result = $client->request('GET', 'webhooks');
+```
+
+## License
+
+MIT

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "mimepost/mimepost-php",
+    "description": "Simple PHP SDK for MimePost API",
+    "type": "library",
+    "license": "MIT",
+    "autoload": {
+        "psr-4": {
+            "MimePost\\": "src/"
+        }
+    },
+    "require": {
+        "php": ">=7.4",
+        "ext-json": "*"
+    }
+}

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace MimePost;
+
+/**
+ * Simple PHP SDK for the MimePost API.
+ *
+ * @see https://mimepost.com/
+ */
+class Client
+{
+    /** @var string */
+    private $apiToken;
+
+    /** @var string */
+    private $baseUrl;
+
+    /** @var string */
+    private $userAgent;
+
+    /**
+     * Create a new client instance.
+     *
+     * @param string $apiToken  Your API token from the MimePost dashboard.
+     * @param string $baseUrl   Base URL for the API (defaults to the public API).
+     * @param string $userAgent Optional custom User-Agent.
+     */
+    public function __construct(string $apiToken, string $baseUrl = 'https://api.mimepost.com/v1/', string $userAgent = 'mimepost-php-sdk/1.0')
+    {
+        $this->apiToken = $apiToken;
+        $this->baseUrl = rtrim($baseUrl, '/') . '/';
+        $this->userAgent = $userAgent;
+    }
+
+    /**
+     * Send an HTTP request to the MimePost API.
+     *
+     * @param string     $method HTTP method (GET, POST, etc.).
+     * @param string     $path   Request path relative to the base URL.
+     * @param array|null $body   Associative array to send as JSON body.
+     *
+     * @return array Decoded JSON response.
+     */
+    public function request(string $method, string $path, ?array $body = null): array
+    {
+        $url = $this->baseUrl . ltrim($path, '/');
+
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, strtoupper($method));
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Content-Type: application/json',
+            'X-Auth-Token: ' . $this->apiToken,
+            'User-Agent: ' . $this->userAgent,
+        ]);
+
+        if ($body !== null) {
+            $json = json_encode($body);
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $json);
+        }
+
+        $response = curl_exec($ch);
+        if ($response === false) {
+            throw new \RuntimeException('cURL error: ' . curl_error($ch));
+        }
+
+        $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        $decoded = json_decode($response, true);
+        if ($statusCode >= 400) {
+            $message = is_array($decoded) && isset($decoded['message']) ? $decoded['message'] : 'HTTP ' . $statusCode;
+            throw new \RuntimeException($message, $statusCode);
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * Send a transactional email using a template.
+     *
+     * @param array $payload Request body as documented in the API.
+     */
+    public function sendEmail(array $payload): array
+    {
+        return $this->request('POST', 'emails/', $payload);
+    }
+
+    /**
+     * List available templates.
+     */
+    public function listTemplates(): array
+    {
+        return $this->request('GET', 'templates/');
+    }
+
+    /**
+     * Fetch a single template by its UID.
+     */
+    public function getTemplate(string $templateUid): array
+    {
+        return $this->request('GET', 'templates/' . $templateUid);
+    }
+
+    /**
+     * Create a new template.
+     */
+    public function createTemplate(array $payload): array
+    {
+        return $this->request('POST', 'templates/', $payload);
+    }
+
+    /**
+     * List all domains associated with the account.
+     */
+    public function listDomains(): array
+    {
+        return $this->request('GET', 'domains');
+    }
+
+    /**
+     * List registered webhooks.
+     */
+    public function listWebhooks(): array
+    {
+        return $this->request('GET', 'webhooks');
+    }
+
+    /**
+     * Get summary statistics.
+     *
+     * @param array $query Optional query parameters.
+     */
+    public function getStats(array $query = []): array
+    {
+        $path = 'stats';
+        if ($query) {
+            $path .= '?' . http_build_query($query);
+        }
+        return $this->request('GET', $path);
+    }
+}


### PR DESCRIPTION
## Summary
- add PSR-4 autoloadable `Client` class for calling MimePost API
- include helpers for sending emails, templates, domains, webhooks and stats
- document installation and usage with composer

## Testing
- `php -l src/Client.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68c191ac9b988326bc3aef0c287fdd41